### PR TITLE
Use optimal bundled library names

### DIFF
--- a/Platforms/Arduino/ESP/libraries/Ethernet/library.properties
+++ b/Platforms/Arduino/ESP/libraries/Ethernet/library.properties
@@ -1,4 +1,4 @@
-name=Ethernet(esp8266)
+name=Ethernet
 version=1.0.4
 author=Arduino
 maintainer=Arduino <info@arduino.cc>

--- a/Platforms/Arduino/ESP/libraries/SD/library.properties
+++ b/Platforms/Arduino/ESP/libraries/SD/library.properties
@@ -1,4 +1,4 @@
-name=SD(esp8266)
+name=SD
 version=1.0.5
 author=Arduino, SparkFun
 maintainer=Arduino <info@arduino.cc>

--- a/Platforms/Arduino/ESP/libraries/Servo/library.properties
+++ b/Platforms/Arduino/ESP/libraries/Servo/library.properties
@@ -1,4 +1,4 @@
-name=Servo(esp8266)
+name=Servo
 version=1.0.2
 author=Michael C. Miller
 maintainer=GitHub/esp8266/arduino


### PR DESCRIPTION
When multiple libraries contain files matching an `#include` directive in the program, the Arduino build system must pick one to use for compilation. Multiple factors are used in order to make an intelligent determination of which library is best, as documented [here](https://arduino.github.io/arduino-cli/dev/sketch-build-process/#dependency-resolution).

In order to enhance this determination, the closeness of match between [the library.properties `name` value](https://arduino.github.io/arduino-cli/latest/library-specification/#libraryproperties-file-format) and the filename in the `#include` directive is being added as one of those factors. This new factor is referred to as [**"Library Name Priority"**](https://arduino.github.io/arduino-cli/dev/sketch-build-process/#library-name-priority). This change has been made in Arduino CLI (though not yet released): https://github.com/arduino/arduino-cli/pull/1300. It will propagate from there to the classic Arduino IDE, Arduino IDE 2.x, and Arduino Web Editor after the next release of Arduino CLI.

Unfortunately, this change can result in [platform bundled libraries](https://arduino.github.io/arduino-cli/latest/platform-specification/#platform-bundled-libraries) which had previously been correctly correctly chosen
no longer being given priority over their equivalent standalone libraries, which may be incompatible or not optimized for the platform's boards.

This priority inversion only occurs when all the following conditions are true:

- There is a standalone library installed which provides a header filename collision.
- The platform bundled library is architecture optimized (e.g., `architectures=esp32`).
- The standalone library is architecture compatible (`architectures=*`).
- The standalone library has better ["Library Name Priority"](https://arduino.github.io/arduino-cli/dev/sketch-build-process/#library-name-priority) (e.g., `name=SD` vs `name=SD(ESP32)` for a library with primary header file `SD.h`.

The fix is to simply give the platform bundled library a perfect ["Library Name Priority"](https://arduino.github.io/arduino-cli/dev/sketch-build-process/#library-name-priority), as provided by the change in this PR.

Some platform bundled libraries were given a modified name as a workaround to [a bug](https://github.com/arduino/Arduino/issues/4189) in the Arduino IDE's Library Manager which caused Library Manager to always show the library as updatable under specific circumstances. That bug was fixed in [Arduino IDE 1.8.6](https://github.com/arduino/Arduino/commit/ac6d3c1afffd81d429498b9d00bc2c92f849cbfe), ~3 years ago.

For more information or discussion regarding this change, please see https://github.com/arduino/arduino-cli/issues/1292